### PR TITLE
Simplify empty namespace attribute selector test

### DIFF
--- a/spec/css/selector.hrx
+++ b/spec/css/selector.hrx
@@ -81,10 +81,10 @@
 <===>
 ================================================================================
 <===> attribute/empty_namespace/input.scss
-[|a="b"] {a: b;}
+[|a] {a: b;}
 
 <===> attribute/empty_namespace/output.css
-[|a=b] {
+[|a] {
   a: b;
 }
 


### PR DESCRIPTION
by removing the operator and right-hand value as this gets quoted in LibSass but not dart-sass. [skip dart-sass]